### PR TITLE
Pairs of non-hex XML character entities are dropped during text node processing

### DIFF
--- a/sax.js
+++ b/sax.js
@@ -59,7 +59,7 @@ function parse(source,defaultNSMapCopy,entityMap,domBuilder,errorHandler){
 	}
 	function appendText(end){//has some bugs
 		// support for xml entities encoded using &#xAA;&#xBB; where AA+BB are hex
-		var xt = source.substring(start,end).replace(/&#?x?(\w+);&#?x?(\w+);/g, function(a, b, c) { return new Buffer(b + c, 'hex').toString() }); 
+		var xt = source.substring(start,end).replace(/&#x(\w+);&#x(\w+);/g, function(a, b, c) { return new Buffer(b + c, 'hex').toString() }); 
 		xt = xt.replace(/&#?\w+;/g,entityReplacer);
 		locator&&position(start);
 		domBuilder.characters(xt,0,end-start);

--- a/test/node.js
+++ b/test/node.js
@@ -43,6 +43,21 @@ wows.describe('XML Node Parse').addBatch({
     	console.assert ( root.firstChild.nextSibling.nextSibling.nextSibling.nodeValue ==' comment ');
     	console.assert ( root.firstChild.nextSibling.nextSibling.nextSibling.nextSibling.nodeValue =='end');
     },
+    'text node with no character entities': function() {
+    	var dom = new DOMParser().parseFromString('<xml>test value</xml>');
+    	var root = dom.documentElement;
+    	console.assert ( root.firstChild.textContent =='test value');
+    },
+    'text node with two one-byte character entities': function () {
+    	var dom = new DOMParser().parseFromString('<xml>&lt;inner&gt;&lt;/inner&gt;</xml>');
+    	var root = dom.documentElement;
+    	console.assert ( root.firstChild.textContent =='<inner><inner>');
+    },
+    'text node with a two-byte character entity': function () {
+    	var dom = new DOMParser().parseFromString('<xml>f&#xC3;&#xBC;n</xml>');
+    	var root = dom.documentElement;
+    	console.assert ( root.firstChild.textContent =='fün');
+    },
     'append node': function () {
     	var dom = new DOMParser().parseFromString('<xml/>');
     	var child = dom.createElement("child");


### PR DESCRIPTION
Fixed an issue where logic which was added to convert two hex-encoded character entities into a single unicode encoded value was incorrectly dropping built-in character entities (ex. &gt; &amp; &lt; etc.) that occur in pairs.