### PR TITLE
Fixes parsing of unicode character entities in text nodes

### DIFF
--- a/sax.js
+++ b/sax.js
@@ -58,12 +58,10 @@ function parse(source,defaultNSMapCopy,entityMap,domBuilder,errorHandler){
 		}
 	}
 	function appendText(end){//has some bugs
-		// support for xml entities encoded using &#xAA;&#xBB; where AA+BB are hex
-		var xt = source.substring(start,end).replace(/&#x(\w+);&#x(\w+);/g, function(a, b, c) { return new Buffer(b + c, 'hex').toString() }); 
-		xt = xt.replace(/&#?\w+;/g,entityReplacer);
+		var xt = source.substring(start,end).replace(/&#?\w+;/g,entityReplacer);
 		locator&&position(start);
 		domBuilder.characters(xt,0,end-start);
-		start = end
+		start = end;
 	}
 	function position(start,m){
 		while(start>=endPos && (m = linePattern.exec(source))){

--- a/test/node.js
+++ b/test/node.js
@@ -47,17 +47,46 @@ wows.describe('XML Node Parse').addBatch({
     	var dom = new DOMParser().parseFromString('<xml>test value</xml>');
     	var root = dom.documentElement;
     	console.assert ( root.firstChild.textContent =='test value');
-    },
+	},
+	/** 
+	 * These tests were added to confirm a change that removed logic which was
+	 * inappropriately converting pairs of Unicode code point character entities
+	 * into a single value.
+	 * 
+	 * This appears to be against the XML 1.0 specification "Section 4.1:
+	 * Character and Entity References":
+	 * 
+	 * > If the character reference begins with " &#x ", the digits and letters
+	 * > up to the terminating ; provide a hexadecimal representation of the
+	 * > character's code point in ISO/IEC 10646. If it begins just with " &# ",
+	 * > the digits up to the terminating ; provide a decimal representation of
+	 * > the character's code point.
+	 * 
+	 * {@link https://www.w3.org/TR/xml/#sec-references}
+	 */
     'text node with two one-byte character entities': function () {
     	var dom = new DOMParser().parseFromString('<xml>&lt;inner&gt;&lt;/inner&gt;</xml>');
     	var root = dom.documentElement;
-    	console.assert ( root.firstChild.textContent =='<inner><inner>');
-    },
+    	console.assert ( root.firstChild.textContent =='<inner></inner>');
+	},
     'text node with a two-byte character entity': function () {
     	var dom = new DOMParser().parseFromString('<xml>f&#xC3;&#xBC;n</xml>');
     	var root = dom.documentElement;
+    	console.assert ( root.firstChild.textContent =='fÃ¼n');
+	},
+	'text node with a single two-byte character entity': function () {
+    	var dom = new DOMParser().parseFromString('<xml>f&#x00FC;n</xml>');
+    	var root = dom.documentElement;
     	console.assert ( root.firstChild.textContent =='fün');
-    },
+	},
+	'text node with two one-byte Unicode character entities': function () {
+		var dom = new DOMParser().parseFromString('<xml>kchen&#x4E03;&#x5473;@shichimitogarashi.org</xml>');
+    	var root = dom.documentElement;
+    	console.assert ( root.firstChild.textContent =='kchen七味@shichimitogarashi.org');
+	},
+	/**
+	 * End of unicode tests
+	 */
     'append node': function () {
     	var dom = new DOMParser().parseFromString('<xml/>');
     	var child = dom.createElement("child");


### PR DESCRIPTION
Removed code that was converting pairs of character entities containing hexidecimal Unicode code point values into a single value. This addresses a disparity between the `auth0/xmldom` implementation and the XML 1.0 specification which explicitly states:

> If the character reference begins with " &#x ", the digits and letters up to the terminating ; provide a hexadecimal representation of the character's code point in ISO/IEC 10646. If it begins just with " &# ", the digits up to the terminating ; provide a decimal representation of the character's code point.
https://www.w3.org/TR/xml/#sec-references

